### PR TITLE
Release Git v2.26.0 beta4

### DIFF
--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -3,7 +3,7 @@ Type=PortableApps.comFormat
 Version=3.5
 
 [Details]
-Name=GitPortable Portable
+Name=Git Portable
 AppID=GitPortable
 Publisher=Git SCM
 Homepage=https://git-scm.com/download/win
@@ -29,6 +29,7 @@ UsesDotNetVersion=
 [Control]
 Icons=1
 Start=GitPortable.exe
+
 [Associations]
 FileTypes=
 FileTypeCommandLine=
@@ -40,7 +41,9 @@ SendTo=
 SendToCommandLine=
 Shell=
 ShellCommand=
+
 [FileTypeIcons]
+
 [Version]
 PackageVersion=2.26.0.0
-DisplayVersion=2.26.0-beta3-uroesch
+DisplayVersion=2.26.0-beta4-uroesch

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,6 +1,6 @@
 [Version]
 Package = 2.26.0.0
-Display = 2.26.0-beta3-uroesch
+Display = 2.26.0-beta4-uroesch
 
 [Archive]
 URL1         = https://github.com/git-for-windows/git/releases/download/v2.26.0.windows.1/PortableGit-2.26.0-32-bit.7z.exe 


### PR DESCRIPTION
Summary:
  * Removing the redundant Portable from
    the app name in appinfo.ini.