### PR TITLE
Close #114 SSH not in path under git-cmd

### DIFF
--- a/App/AppInfo/Launcher/GitCmdPortable.ini
+++ b/App/AppInfo/Launcher/GitCmdPortable.ini
@@ -11,6 +11,7 @@ MinOS=Vista
 
 [Environment]
 HOME=%PAL:DataDir%\home
+PATH=%PAL:AppDir%\Git\bin;%PAL:AppDir%\Git\usr\bin;%PATH%
 
 [FileWrite1]
 Type=Replace

--- a/App/AppInfo/appinfo.ini
+++ b/App/AppInfo/appinfo.ini
@@ -51,5 +51,5 @@ ShellCommand                  =
 [FileTypeIcons]
 
 [Version]
-PackageVersion = 2.35.1.4
-DisplayVersion = 2.35.1.2-beta7-uroesch
+PackageVersion = 2.35.1.5
+DisplayVersion = 2.35.1.2-beta8-uroesch

--- a/App/AppInfo/update.ini
+++ b/App/AppInfo/update.ini
@@ -1,7 +1,7 @@
 [Version]
 Upstream = 2.35.1
-Package  = 2.35.1.4
-Display  = 2.35.1.2-beta7-uroesch
+Package  = 2.35.1.5
+Display  = 2.35.1.2-beta8-uroesch
 
 [Archive]
 URL1         = https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.2/PortableGit-2.35.1.2-32-bit.7z.exe

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ more user friendly notation `...\PortableApps\GitPortable\Data\home`.
 
 All the private SSH keys should be stored under the home's `.ssh` directory.
 
-### Git bash
+### Git Bash
 
 #### OpenSSH
 
@@ -159,18 +159,14 @@ Receiving objects: 100% (856/856), 419.32 KiB | 657.00 KiB/s, done.
 Resolving deltas: 100% (386/386), done.
 ```
 
-### Git CMD
-
-**Note**: There is currently a bug (#114) which prevents creating keys within
- the windows terminal version. In detail the directory holding the ssh binaries
- `C:\Windows\System32\OpenSSH` is not accessible from within the `git-cmd` terminal.
-  The problem seems to be upstream not with this package.
+### Git Cmd
 
 #### OpenSSH
 
-When using the Git CMD terminal use a plain vanilla Windows CMD or PowerShell
-terminal to create the key or follow the instructions using the outlined in
-the `git-bash` section.
+##### Generating a private key and public ssh key
+
+To create a ssh private and public key follo the instructions under
+the **Git Bash** section they are identical under `git-cmd`.
 
 ##### Passwordless git over SSH
 


### PR DESCRIPTION
Summary:
  * For some reason the path does not extend
    to the binaries under `%PAL:AppDir%\usr\bin`.
    Adding it to the launcher ini file fixes the
    issue.